### PR TITLE
Introduce intake catalog dir environment var

### DIFF
--- a/om4labs/diags/heat_transport/heat_transport.py
+++ b/om4labs/diags/heat_transport/heat_transport.py
@@ -2,7 +2,6 @@
 
 import argparse
 import pkg_resources as pkgr
-import intake
 import io
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -15,6 +14,7 @@ import warnings
 from om4labs.om4common import horizontal_grid
 from om4labs.om4common import image_handler
 from om4labs.om4common import date_range
+from om4labs.om4common import open_intake_catalog
 from om4labs.om4parser import default_diag_parser
 
 warnings.filterwarnings("ignore", message=".*csr_matrix.*")
@@ -180,14 +180,7 @@ class GWObs:
         self.indpac = self._gw(
             np.array([-30.0, -18.0, 24.0, 47.0]),
             np.array([-0.9, -1.6, 0.52, 0.0]),
-            np.array(
-                [
-                    0.3,
-                    0.6,
-                    0.2,
-                    0.05,
-                ]
-            ),
+            np.array([0.3, 0.6, 0.2, 0.05,]),
         )
 
 
@@ -196,9 +189,7 @@ def plot(dictArgs, yq, trans_global, trans_atlantic, trans_pacific, dates=None):
     # Load observations for plotting
     GW = GWObs()
 
-    cat_platform = "catalogs/obs_catalog_" + dictArgs["platform"] + ".yml"
-    catfile = pkgr.resource_filename("om4labs", cat_platform)
-    cat = intake.open_catalog(catfile)
+    cat = open_intake_catalog(dictArgs["platform"], "obs")
     fObs = cat["Trenberth_and_Caron"].to_dask()
 
     yobs = fObs.ylat.to_masked_array()

--- a/om4labs/diags/seaice/seaice.py
+++ b/om4labs/diags/seaice/seaice.py
@@ -24,6 +24,7 @@ from om4labs.om4common import (
     curv_to_curv,
     date_range,
     image_handler,
+    open_intake_catalog,
     standard_grid_cell_area,
 )
 from om4labs.om4parser import default_diag_parser
@@ -128,10 +129,8 @@ def read(dictArgs):
     if dictArgs["obsfile"] is not None:
         dobs = xr.open_dataset(dictArgs["obsfile"])
     else:
-        cat_platform = "catalogs/obs_catalog_" + dictArgs["platform"] + ".yml"
-        catfile = pkgr.resource_filename("om4labs", cat_platform)
-        cat = intake.open_catalog(catfile)
-        dobs = cat[dictArgs["dataset"]].to_dask()
+        cat = open_intake_catalog(dictArgs["platform"], "obs")
+        dobs = cat[f"NSIDC_{dictArgs['region'].upper()}_monthly"].to_dask()
 
     # Close the static file (no longer used)
     dstatic.close()

--- a/om4labs/om4common.py
+++ b/om4labs/om4common.py
@@ -583,7 +583,9 @@ def horizontal_grid(
 def open_intake_catalog(platform, config):
     """Returns an Intake catalog for a specified platform and config
 
-    Uses the package resources included in the om4labs distribution.
+    Uses the package resources included in the om4labs distribution
+    to determine the directory of the intake catalogs, unless it
+    is overridden by the "OM4LABS_CATALOG_DIR" environment var.
 
     Parameters
     ----------
@@ -597,9 +599,16 @@ def open_intake_catalog(platform, config):
     intake.catalog.Catalog
         Intake catalog corresponding to specified platform/config
     """
-    cat_platform = f"catalogs/{config}_catalog_{platform}.yml"
-    catfile = pkgr.resource_filename("om4labs", cat_platform)
+
+    catalog_str = f"{config}_catalog_{platform}.yml"
+
+    if "OM4LABS_CATALOG_DIR" in os.environ.keys():
+        catfile = f"{os.environ['OM4LABS_CATALOG_DIR']}/{catalog_str}"
+    else:
+        catfile = pkgr.resource_filename("om4labs", f"catalogs/{catalog_str}")
+
     cat = intake.open_catalog(catfile)
+
     return cat
 
 


### PR DESCRIPTION
When calling om4labs in a complex stack (e.g. unicorn --> flask --> om4labs), package_resources is not resolving the intake catalog paths correctly.  This PR introduces an environment variable "OM4LABS_CATALOG_DIR" that can be used to override the automatic path resolution of the directory that contains the intake catalogs.