### PR TITLE
Write out transport timeseries to netCDF

### DIFF
--- a/om4labs/diags/section_transports/section_transports.py
+++ b/om4labs/diags/section_transports/section_transports.py
@@ -147,6 +147,13 @@ def parse(cliargs=None, template=False):
     )
 
     parser.add_argument(
+        "--netcdf",
+        type=str,
+        default=None,
+        help="Name of NetCDF file containing passage timeseries. Default is None.",
+    )
+
+    parser.add_argument(
         "ppdir",
         metavar="PPDIR",
         type=str,
@@ -179,6 +186,15 @@ def run(dictArgs):
 
     # calculate the transports for each of the passages
     passages = [x.calculate() for x in passages]
+
+    # save timeseries to netcdf format if requested
+    if dictArgs["netcdf"] is not None:
+        ds_out = xr.Dataset()
+        for x in passages:
+            if x.transport is not None:
+                outvarname = x.passage_label.replace(" ", "_").replace("-", "_")
+                ds_out[outvarname] = x.transport
+                ds_out.to_netcdf(f"{dictArgs['outdir']}/{dictArgs['netcdf']}", mode="w")
 
     # loop over passages and call their plot method
     figs = [passage.plot() for passage in passages if passage.transport is not None]


### PR DESCRIPTION
This PR addresses the feature request b @stephengriffies to be able plot transports from multiple experiments on the same plot.  It is cost-prohibitive to do this in the web server framework (too many inodes open, dmget issues, etc.) but we can provide the user with a NetCDF file of the raw data.  Those files could be used to generate custom plots.

This works out-of-the-box on the command line.  It is a bit more tricky to have the web server generate the file for download, but is still do-able.