### PR TITLE
Bugfix for dpi feature

### DIFF
--- a/om4labs/om4common.py
+++ b/om4labs/om4common.py
@@ -265,7 +265,7 @@ def image_handler(figs, dictArgs, dpi=100, filename="./figure"):
     """
 
     # Set default dpi
-    dpi = dictArgs["dpi"] if dpi in dictArgs.keys() else dpi
+    dpi = dictArgs["dpi"] if "dpi" in dictArgs.keys() else dpi
 
     imgbufs = []
     numfigs = len(figs)


### PR DESCRIPTION
- dictionary key should be a string; otherwise behavior
  incorrectly looks for the kwarg as a dict key